### PR TITLE
Clients can now be put in 'raw responses' mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,8 @@ It returns the equivalent of PHP's [`SoapClient::__getTypes()`](http://php.net/m
 
 #### returningRawResponses()
 
-Returns a new Client instance that returns raw responses instead of responses parsed by the SoapClient class.
-You can use this when you want to retrieve the cookies, or other headers of the response, or just parse the
-response yourself.
+Returns a new Client instance that returns raw response XML instead of responses parsed by the SoapClient class.
+Use this when you want to parse the response XML yourself.
 
 ### Proxy
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ It returns the equivalent of PHP's [`SoapClient::__getFunctions()`](http://php.n
 The `getTypes()` method returns an array of types defined in the WSDL.
 It returns the equivalent of PHP's [`SoapClient::__getTypes()`](http://php.net/manual/en/soapclient.gettypes.php).
 
+#### returningRawResponses()
+
+Returns a new Client instance that returns raw responses instead of responses parsed by the SoapClient class.
+You can use this when you want to retrieve the cookies, or other headers of the response, or just parse the
+response yourself.
+
 ### Proxy
 
 The `Proxy` class wraps an existing [`Client`](#client) instance in order to ease calling

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "clue/buzz-react": "0.1.*",
+        "clue/buzz-react": "0.4.*",
         "react/event-loop": "0.3.*|0.4.*",
         "react/promise": "~1.0|~2.0",
         "ext-soap": "*"

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,9 +54,9 @@ class Client
     public function handleResponse(Response $response)
     {
         if ($this->rawResponses) {
-            return $response;
+            return (string) $response->getBody();
         } else {
-            return $this->decoder->decode((string)$response->getBody());
+            return $this->decoder->decode((string) $response->getBody());
         }
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -32,7 +32,7 @@ class Client
         $this->browser = $browser;
         $this->encoder = $encoder;
         $this->decoder = $decoder;
-        $this->rawResponses = true;
+        $this->rawResponses = false;
     }
 
     public function soapCall($name, $args)

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,6 +16,7 @@ class Client
     private $browser;
     private $encoder;
     private $decoder;
+    private $rawResponses;
 
     public function __construct($wsdl, Browser $browser, ClientEncoder $encoder = null, ClientDecoder $decoder = null)
     {
@@ -31,6 +32,7 @@ class Client
         $this->browser = $browser;
         $this->encoder = $encoder;
         $this->decoder = $decoder;
+        $this->rawResponses = true;
     }
 
     public function soapCall($name, $args)
@@ -51,7 +53,11 @@ class Client
 
     public function handleResponse(Response $response)
     {
-        return $this->decoder->decode((string)$response->getBody());
+        if ($this->rawResponses) {
+            return $response;
+        } else {
+            return $this->decoder->decode((string)$response->getBody());
+        }
     }
 
     public function handleError(Exception $error)
@@ -67,5 +73,12 @@ class Client
     public function getTypes()
     {
         return $this->encoder->__getTypes();
+    }
+
+    public function returningRawResponses()
+    {
+        $copy = clone $this;
+        $copy->rawResponses = true;
+        return $copy;
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -45,7 +45,7 @@ class FunctionalTest extends TestCase
         $this->expectPromiseResolve($promise);
         $result = $this->waitForPromise($promise, $this->loop);
 
-        $this->assertInstanceof('\Clue\React\Buzz\Message\Response', $result);
+        $this->assertTrue(is_string($result));
     }
 
     public function testBlzServiceWithInvalidBlz()

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -36,6 +36,18 @@ class FunctionalTest extends TestCase
         $this->assertInternalType('object', $result);
     }
 
+    public function testRawResponses()
+    {
+        $api = new Proxy($this->client->returningRawResponses());
+
+        $promise = $api->getBank(array('blz' => '12070000'));
+
+        $this->expectPromiseResolve($promise);
+        $result = $this->waitForPromise($promise, $this->loop);
+
+        $this->assertInstanceof('\Clue\React\Buzz\Message\Response', $result);
+    }
+
     public function testBlzServiceWithInvalidBlz()
     {
         $api = new Proxy($this->client);


### PR DESCRIPTION
Allows you to receive the raw Response object instead of just the response as parsed by SoapClient.