### PR TITLE
Update dependencies, use Laminas Diactoros, ~update signature for `Encoder::_doRequest` and `Decoder::_doRequest`~

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     },
     "require": {
         "php": ">=7.1",
-        "react/http": "^1.5",
-        "react/promise": "^2.1 || ^1.2",
+        "react/http": "^1.11",
+        "react/promise": "^3.2 || ^2.1 || ^1.2",
         "ext-soap": "*"
     },
     "require-dev": {
-        "clue/block-react": "^1.0",
-        "phpunit/phpunit": "^9.3 || ^7.5"
+        "react/async": "^4.3 || ^3.2",
+        "phpunit/phpunit": "^9.6 || ^7.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=7.1",
         "react/http": "^1.11",
         "react/promise": "^3.2 || ^2.1 || ^1.2",
+        "laminas/laminas-diactoros": "^3.5 || ^2.4",
         "ext-soap": "*"
     },
     "require-dev": {

--- a/src/Protocol/ClientEncoder.php
+++ b/src/Protocol/ClientEncoder.php
@@ -3,7 +3,8 @@
 namespace Clue\React\Soap\Protocol;
 
 use Psr\Http\Message\RequestInterface;
-use RingCentral\Psr7\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\StreamFactory;
 
 /**
  * @internal
@@ -56,11 +57,13 @@ final class ClientEncoder extends \SoapClient
             );
         }
 
+        $body = (new StreamFactory())->createStream((string)$request);
+
         $this->request = new Request(
-            'POST',
             (string)$location,
-            $headers,
-            (string)$request
+            'POST',
+            $body,
+            $headers
         );
 
         // do not actually block here, just pretend we're done...

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -2,12 +2,12 @@
 
 namespace Clue\Tests\React\Soap;
 
-use Clue\React\Block;
+use React\Async;
+use React\Http\Browser;
 use Clue\React\Soap\Client;
 use Clue\React\Soap\Proxy;
 use PHPUnit\Framework\TestCase;
-use React\EventLoop\Loop;
-use React\Http\Browser;
+
 
 class BankResponse
 {
@@ -55,7 +55,7 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $result = Block\await($promise, Loop::get());
+        $result = Async\await($promise);
 
         $this->assertIsObject($result);
         $this->assertTrue(isset($result->details));
@@ -77,7 +77,7 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $result = Block\await($promise, Loop::get());
+        $result = Async\await($promise);
 
         $this->assertInstanceOf('Clue\Tests\React\Soap\BankResponse', $result);
         $this->assertTrue(isset($result->details));
@@ -97,7 +97,7 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $result = Block\await($promise, Loop::get());
+        $result = Async\await($promise);
 
         $this->assertIsObject($result);
         $this->assertTrue(isset($result->details));
@@ -117,7 +117,7 @@ class FunctionalTest extends TestCase
         // $promise = $api->getBank(new SoapParam('12070000', 'ns1:blz'));
         $promise = $api->getBank(new \SoapVar('12070000', XSD_STRING, null, null, 'blz', 'http://thomas-bayer.com/blz/'));
 
-        $result = Block\await($promise, Loop::get());
+        $result = Async\await($promise);
 
         $this->assertIsObject($result);
         $this->assertFalse(isset($result->details));
@@ -158,7 +158,7 @@ class FunctionalTest extends TestCase
 
         $this->expectException(\SoapFault::class);
         $this->expectExceptionMessage('Function ("doesNotExist") is not a valid method for this service');
-        Block\await($promise, Loop::get());
+        Async\await($promise);
     }
 
     public function testCancelMethodRejectsWithRuntimeException()
@@ -170,7 +170,7 @@ class FunctionalTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('cancelled');
-        Block\await($promise, Loop::get());
+        Async\await($promise);
     }
 
     public function testTimeoutRejectsWithRuntimeException()
@@ -185,7 +185,7 @@ class FunctionalTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('timed out');
-        Block\await($promise, Loop::get());
+        Async\await($promise);
     }
 
     public function testGetLocationForFunctionName()
@@ -236,7 +236,7 @@ class FunctionalTest extends TestCase
         $promise = $api->getBank(array('blz' => '12070000'));
 
         $this->expectException(\RuntimeException::class);
-        Block\await($promise, Loop::get());
+        Async\await($promise);
     }
 
     public function testWithLocationRestoredToOriginalResolves()
@@ -248,7 +248,7 @@ class FunctionalTest extends TestCase
 
         $promise = $api->getBank(array('blz' => '12070000'));
 
-        $result = Block\await($promise, Loop::get());
+        $result = Async\await($promise);
         $this->assertIsObject($result);
     }
 }


### PR DESCRIPTION
First, thank you so much for ReactPHP and ReactPHP-Soap! I am using both in a small project and bring a very nice improvement in performance.

I noticed that:

- the dependencies for this project are a bit old. For instance, the blocking library is deprectaed in favour or React/Async
- plus there's an undocumented dependency on the RingCentral's PSR7 library

I went ahead and tried to address these observations:

- updating dependencies,
- moving from RingCentral's PSR7 library to Laminas Diactoros, which is maintained at the moment
- moved from usage of '\Clue\React\Block' to 'Async\Await'

Looking forward to your feedback!

EDIT: Since promises aims to support older PHP versions, I am dropping the `_doRequest` signature update to not break compatibility with PHP<8.0